### PR TITLE
Both the ellipse path to the folder containing results or file itself now work.

### DIFF
--- a/GUI/fit_gui.py
+++ b/GUI/fit_gui.py
@@ -640,7 +640,7 @@ class MainWindow(QMainWindow):
         if ellipse_fit_p != None:
             # ellipse_fit_data = pd.DataFrame(columns=["file", "PolarOrHost","IsoLevel", "x_center", "y_center", "semi_major", "semi_minor", "angle"])
 
-            # IsoLevel and IsophoteLevel aren't currently used anywhere to my knowledge. Updated the separation so that with both ellipse result files included it will run properly, as one is comma delineated and the other space delineated. To my knowledge, both are needed atm, so I'm adding back the ability for both to be used if the folder containing ellipse results is passed.
+            # IsoLevel and IsophoteLevel aren't currently used anywhere to my knowledge, so I'll keep both for the time being. Updated the separation so that with both ellipse result files included it will run properly, as one is comma delineated and the other space delineated. Either the path to the particular file
             ellipse_fit_data = pd.DataFrame(columns=["file","x_center","y_center","semi_major","semi_minor","angle","MorphType","PSType1","PolarOrHost","IsophoteLevel","IsoLevel"])
 
             if not str(ellipse_fit_p).endswith("csv"):

--- a/GUI/fit_gui.py
+++ b/GUI/fit_gui.py
@@ -639,12 +639,26 @@ class MainWindow(QMainWindow):
         # Read in the ellipse fit data 
         if ellipse_fit_p != None:
             # ellipse_fit_data = pd.DataFrame(columns=["file", "PolarOrHost","IsoLevel", "x_center", "y_center", "semi_major", "semi_minor", "angle"])
-            ellipse_fit_data = pd.DataFrame(columns=["file","x_center","y_center","semi_major","semi_minor","angle","MorphType","PSType1","PolarOrHost","IsophoteLevel"])
-            try:
-                dat = pd.read_csv(Path(ellipse_fit_p), sep = ",")
-                ellipse_fit_data = pd.concat([ellipse_fit_data, dat])
-            except Exception as e:
-                print(e)
+
+            # IsoLevel and IsophoteLevel aren't currently used anywhere to my knowledge. Updated the separation so that with both ellipse result files included it will run properly, as one is comma delineated and the other space delineated. To my knowledge, both are needed atm, so I'm adding back the ability for both to be used if the folder containing ellipse results is passed.
+            ellipse_fit_data = pd.DataFrame(columns=["file","x_center","y_center","semi_major","semi_minor","angle","MorphType","PSType1","PolarOrHost","IsophoteLevel","IsoLevel"])
+
+            if not str(ellipse_fit_p).endswith("csv"):
+                csvs = glob.glob(os.path.join(Path(ellipse_fit_p), "*csv"))
+                for csv in csvs:
+                    try:
+                        dat = pd.read_csv(csv, sep = r"\s+|,",
+                    engine="python")
+                        ellipse_fit_data = pd.concat([ellipse_fit_data, dat])
+                    except Exception as e:
+                        print(e)
+            else:
+                try:
+                    dat = pd.read_csv(Path(ellipse_fit_p), sep = r"\s+|,",
+                engine="python")
+                    ellipse_fit_data = pd.concat([ellipse_fit_data, dat])
+                except Exception as e:
+                    print(e)
             self.ellipse_fit_data = ellipse_fit_data
 
         # Read in the master table (I might change this later so we don't have to do this in the GUI code)

--- a/decomposer/generate_imfit_conf.py
+++ b/decomposer/generate_imfit_conf.py
@@ -49,7 +49,7 @@ def main(args, fit_band = 'all'):
     galpathlist = []
 
     # Gather Ellipse Fit results for all objects
-    csvs = glob.glob(os.path.join(Path(args.ellipse_fit), "*.ecsv"))
+    csvs = glob.glob(os.path.join(Path(args.ellipse_fit), "*csv"))
     ellipse_fit_data = pd.DataFrame(columns=["file", "PolarOrHost","IsoLevel", "x_center", "y_center", "semi_major", "semi_minor", "angle"])
 
     # The following was for the old ellipse fit results
@@ -57,7 +57,8 @@ def main(args, fit_band = 'all'):
     # ellipse_fit_data = pd.DataFrame(columns=["file", "label","contour", "x_center", "y_center", "semi_major", "semi_minor", "angle", "center_offset", "axis_ratio", "pa_diff"])
 
     for csv in csvs:
-        dat = pd.read_csv(csv, sep=" ")
+        dat = pd.read_csv(csv, sep = r"\s+|,",
+                    engine="python")
         ellipse_fit_data = pd.concat([ellipse_fit_data, dat])
     # print(dat.columns)
     # print(ellipse_fit_data)

--- a/decomposer/generate_imfit_conf.py
+++ b/decomposer/generate_imfit_conf.py
@@ -49,19 +49,25 @@ def main(args, fit_band = 'all'):
     galpathlist = []
 
     # Gather Ellipse Fit results for all objects
-    csvs = glob.glob(os.path.join(Path(args.ellipse_fit), "*csv"))
     ellipse_fit_data = pd.DataFrame(columns=["file", "PolarOrHost","IsoLevel", "x_center", "y_center", "semi_major", "semi_minor", "angle"])
+    if not str(args.ellipse_fit).endswith("csv"):
+        csvs = glob.glob(os.path.join(Path(args.ellipse_fit), "*csv"))
+        for csv in csvs:
+            try:
+                dat = pd.read_csv(csv, sep = r"\s+|,",
+            engine="python")
+                ellipse_fit_data = pd.concat([ellipse_fit_data, dat])
+            except Exception as e:
+                print(e)
+    else:
+        try:
+            dat = pd.read_csv(Path(args.ellipse_fit), sep = r"\s+|,",
+        engine="python")
+            ellipse_fit_data = pd.concat([ellipse_fit_data, dat])
+        except Exception as e:
+            print(e)
 
-    # The following was for the old ellipse fit results
-    # csvs = glob.glob(os.path.join(Path(args.ellipse_fit), "*.csv"))
-    # ellipse_fit_data = pd.DataFrame(columns=["file", "label","contour", "x_center", "y_center", "semi_major", "semi_minor", "angle", "center_offset", "axis_ratio", "pa_diff"])
 
-    for csv in csvs:
-        dat = pd.read_csv(csv, sep = r"\s+|,",
-                    engine="python")
-        ellipse_fit_data = pd.concat([ellipse_fit_data, dat])
-    # print(dat.columns)
-    # print(ellipse_fit_data)
     
     # gather infromation from the master_table.csv (currently unused)
     master_table_csv = glob.glob(os.path.join(Path(args.master_table), "master_table.csv"))[0]


### PR DESCRIPTION
I'd talked with some of the other students and showed them how things worked a little when it was just passing the results to the folder containing potentially multiple csvs of the ellipse results, so wanted to ensure that they can still do that as they had been previously as well. Additionally, the script now works for cases where the ellipse results are in any combination of comma and space delineated.